### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -7,7 +7,7 @@ paper:
   authors:
     - name: Tiziano Zito
       ORCID: 0000-0001-5891-1702
-  reference: http://rescience.github.io/bibliography/detorakis_2017.html
+  reference: https://doi.org/10.5281/zenodo.1003214
 
 manifest:
   - file: figures/figure_1.png

--- a/codecheck.yml
+++ b/codecheck.yml
@@ -7,9 +7,7 @@ paper:
   authors:
     - name: Tiziano Zito
       ORCID: 0000-0001-5891-1702
-  reference: >
-    ReScience (2017) 3, 1, 7
-    http://rescience.github.io/bibliography/detorakis_2017.html
+  reference: http://rescience.github.io/bibliography/detorakis_2017.html
 
 manifest:
   - file: figures/figure_1.png


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)